### PR TITLE
edited shebang for portability

### DIFF
--- a/liberia_data.py
+++ b/liberia_data.py
@@ -1,4 +1,4 @@
-#/usr/bin/python
+#!/usr/bin/env python
 
 """
 Caitlin Rivers


### PR DESCRIPTION
My understanding is that the shebang should not be a hard call to /usr/bin/python as it will not play nicely with virtual environments and Python installations across different operating systems.  This should make the script more portable

Please see [1, 2] for more info.

[1] http://stackoverflow.com/questions/17846908/proper-shebang-for-python-script
[2] http://stackoverflow.com/questions/5709616/whats-the-difference-between-these-two-python-shebangs
