### PR TITLE
Update Liberia_case_data - July 10.csv

### DIFF
--- a/liberia_data/Liberia_case_data - July 10.csv
+++ b/liberia_data/Liberia_case_data - July 10.csv
@@ -23,7 +23,7 @@ Date,Variable,National,Bomi County,Bong County,Grand Kru,Lofa County,Margibi Cou
 7/10/2014,Total discharges,3,0,0,0,3,0,0,0,0,0,0,0
 7/10/2014,Cumulative admission/isolation,10,0,0,0,3,0,0,7,0,0,0,0
 7/10/2014,Newly Reported Cases in HCW,4,0,0,0,3,0,0,1,0,0,0,0
-7/10/2014,Cumulative cases among HCW,40,1,0,0,23,2,0,14,0,0,0,0
+7/10/2014,Cumulative cases among HCW,40,0,0,0,5,2,0,6,0,0,0,0
 7/10/2014,Newly Reported deaths in HCW,28,0,0,0,13,0,0,15,0,0,0,0
 7/10/2014,Cumulative deaths among HCW,17,0,0,0,10,0,0,7,0,0,0,0
 7/10/2014,New Case/s (Suspected),2,0,0,0,0,0,0,2,0,0,0,


### PR DESCRIPTION
there were three values in the cumulative cases among HCW that did not make sense: for Bomi, Lofa, and montserrado counties.  They were higher numbers than the cumulative cases that followed on 7/11 and after that. I changed them to match the 7/9 numbers.
