### PR TITLE
Add Sinoe County header

### DIFF
--- a/liberia_data/2014-08-20.csv
+++ b/liberia_data/2014-08-20.csv
@@ -1,4 +1,4 @@
-Date,Variable,National,Bomi County,Bong County,Grand Bassa,Grand Cape Mount,Grand Gedeh,Lofa County,Margibi County,Montserrado County,Nimba County,RiverCess County,
+Date,Variable,National,Bomi County,Bong County,Grand Bassa,Grand Cape Mount,Grand Gedeh,Lofa County,Margibi County,Montserrado County,Nimba County,RiverCess County,Sinoe County
 8/20/14,Specimens collected,41,,2,,,,38,,,1,,
 8/20/14,Specimens pending for testing,99,,8,2,1,,38,4,16,30,,
 8/20/14,Total specimens tested,19,,,,,,19,,,,,


### PR DESCRIPTION
Based on the [August 20th SitRep](http://mohsw.gov.lr/documents/Liberia%20Ebola%20SitRep%2097%20Aug%2020,%202014.pdf), I believe Sinoe County is the missing header in this set.

![mohsw_gov_lr_documents_liberia_ebola_sitrep_97_aug_20__2014_pdf](https://cloud.githubusercontent.com/assets/4944634/4739764/1905d362-5a07-11e4-9123-b75d366656df.png)
