### PR TITLE
Fixed new-line character issues in the Liberia data

### DIFF
--- a/liberia_data/2014-10-21-v159.csv
+++ b/liberia_data/2014-10-21-v159.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/21/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/21/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/21/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/21/2014,"Total death/s in confirmed, 
- probable, suspected cases",2770,71,182,3,42,30,2,17,465,353,10,1438,138,6,8,5
-10/21/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/21/2014,"Total death/s in confirmed,  probable, suspected cases",2770,71,182,3,42,30,2,17,465,353,10,1438,138,6,8,5
+10/21/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/21/2014,Newly reported contacts,90,0,0,0,0,56,2,0,0,0,0,32,0,0,0,0
 10/21/2014,Total contacts listed,19155,686,1307,121,405,267,58,69,756,3036,17,11299,893,31,113,97
 10/21/2014,Currently under follow-up,8677,470,215,71,45,247,3,7,328,1757,17,4863,488,3,66,97
 10/21/2014,Contacts seen,5068,0,0,0,0,247,0,0,0,0,0,4821,0,0,0,0
-10/21/2014,"Contacts who completed 21 day 
- follow-up",299,0,0,0,0,0,0,0,33,0,0,266,0,0,0,0
+10/21/2014,"Contacts who completed 21 day follow-up",299,0,0,0,0,0,0,0,33,0,0,266,0,0,0,0
 10/21/2014,Contacts lost to follow-up,38,0,0,1,0,21,0,0,0,15,0,1,0,0,0,0
 10/21/2014,New admissions,48,1,0,0,0,0,0,0,0,0,0,45,2,0,0,0
-10/21/2014,"Total no. currently in Treatment 
- Units",390,14,0,0,9,0,0,0,5,0,0,352,10,0,0,0
+10/21/2014,"Total no. currently in Treatment Units",390,14,0,0,9,0,0,0,5,0,0,352,10,0,0,0
 10/21/2014,Total discharges,34,3,0,0,0,0,0,0,0,0,0,25,6,0,0,0
 10/21/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/21/2014,Newly Reported Cases in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/21/2014,Total suspected cases,,,,,,,,,,,,,,,,
 10/21/2014,Total probable cases,,,,,,,,,,,,,,,,
 10/21/2014,Total confirmed cases,,,,,,,,,,,,,,,,
-10/21/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",13,0,0,0,0,1,0,0,11,1,0,0,0,0,0,0
-10/21/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",4,3,0,0,0,0,0,0,0,0,0,1,0,0,0,0
+10/21/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",13,0,0,0,0,1,0,0,11,1,0,0,0,0,0,0
+10/21/2014,"Total Number of Confirmed Cases of Guinean Nationality",4,3,0,0,0,0,0,0,0,0,0,1,0,0,0,0
 10/21/2014,"Cumulative confirmed, probable and suspected cases",4772,96,481,10,147,43,4,41,818,632,8,2158,282,19,10,23

--- a/liberia_data/2014-10-22-v160.csv
+++ b/liberia_data/2014-10-22-v160.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/22/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/22/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/22/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/22/2014,"Total death/s in confirmed, 
- probable, suspected cases",2168,45,45,3,51,39,3,18,374,450,8,1082,31,8,1,10
-10/22/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/22/2014,"Total death/s in confirmed, probable, suspected cases",2168,45,45,3,51,39,3,18,374,450,8,1082,31,8,1,10
+10/22/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/22/2014,Newly reported contacts,142,,0,,6,,0,0,0,9,,127,0,0,,0
 10/22/2014,Total contacts listed,,,,,,,,,,,,,,,,
 10/22/2014,Currently under follow-up,7794,,166,,27,,3,7,328,1763,,4914,488,1,,97
 10/22/2014,Contacts seen,6660,,0,,27,,0,0,0,1763,,4869,0,1,,0
-10/22/2014,"Contacts who completed 21 day 
- follow-up",256,,0,,0,,16,0,33,0,,207,0,0,,0
+10/22/2014,"Contacts who completed 21 day follow-up",256,,0,,0,,16,0,33,0,,207,0,0,,0
 10/22/2014,Contacts lost to follow-up,15,,0,,0,,0,0,0,15,,0,0,0,,0
 10/22/2014,New admissions,,,,,,,,,,,,,,,,
-10/22/2014,"Total no. currently in Treatment 
- Units",,,,,,,,,,,,,,,,
+10/22/2014,"Total no. currently in Treatment Units",,,,,,,,,,,,,,,,
 10/22/2014,Total discharges,,,,,,,,,,,,,,,,
 10/22/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/22/2014,Newly Reported Cases in HCW,0,,0,,0,,0,0,0,0,,0,0,0,,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/22/2014,Total suspected cases,2392,69,160,6,36,28,2,11,167,343,9,1461,82,3,5,10
 10/22/2014,Total probable cases,1556,26,35,2,69,9,0,13,151,482,2,662,100,1,1,3
 10/22/2014,Total confirmed cases,2218,59,69,4,16,22,2,2,304,275,2,1343,98,4,4,14
-10/22/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-10/22/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+10/22/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/22/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 10/22/2014,"Cumulative confirmed, probable and suspected cases",6166,154,264,12,121,59,4,26,622,1100,13,3466,280,8,10,27

--- a/liberia_data/2014-10-23-v161.csv
+++ b/liberia_data/2014-10-23-v161.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/23/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/23/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/23/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/23/2014,"Total death/s in confirmed, 
- probable, suspected cases",2104,47,41,3,49,24,2,20,342,457,8,1060,26,7,8,10
-10/23/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/23/2014,"Total death/s in confirmed, probable, suspected cases",2104,47,41,3,49,24,2,20,342,457,8,1060,26,7,8,10
+10/23/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/23/2014,Newly reported contacts,124,,9,,6,0,2,0,23,15,,69,,,,
 10/23/2014,Total contacts listed,,,,,,,,,,,,,,,,
 10/23/2014,Currently under follow-up,7153,,80,,12,202,0,7,298,1771,,4783,,,,
 10/23/2014,Contacts seen,7139,,80,,12,202,0,0,298,1771,,4776,,,,
-10/23/2014,"Contacts who completed 21 day 
- follow-up",599,,86,,333,0,16,0,20,8,,136,,,,
+10/23/2014,"Contacts who completed 21 day follow-up",599,,86,,333,0,16,0,20,8,,136,,,,
 10/23/2014,Contacts lost to follow-up,36,,0,,0,21,0,0,0,15,,0,,,,
 10/23/2014,New admissions,,,,,,,,,,,,,,,,
-10/23/2014,"Total no. currently in Treatment 
- Units",,,,,,,,,,,,,,,,
+10/23/2014,"Total no. currently in Treatment Units",,,,,,,,,,,,,,,,
 10/23/2014,Total discharges,,,,,,,,,,,,,,,,
 10/23/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/23/2014,Newly Reported Cases in HCW,0,,0,,0,0,0,0,0,0,,0,,,,
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/23/2014,Total suspected cases,2428,75,160,6,36,28,2,12,168,347,10,1480,82,7,5,10
 10/23/2014,Total probable cases,1591,38,35,2,69,9,0,13,151,493,2,671,100,4,1,3
 10/23/2014,Total confirmed cases,2229,60,69,4,16,22,2,2,304,279,2,1346,98,7,4,14
-10/23/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-10/23/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+10/23/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/23/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 10/23/2014,"Cumulative confirmed, probable and suspected cases",6248,173,264,12,121,59,4,27,623,1119,14,3497,280,18,10,27

--- a/liberia_data/2014-10-24-v162.csv
+++ b/liberia_data/2014-10-24-v162.csv
@@ -1,7 +1,33 @@
-Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand Cape Mount,Grand Gedeh,Grand Kru,Lofa County,Margibi County,Maryland County,Montserrado County,Nimba County,River Gee County,RiverCess County,Sinoe County10/24/14,Specimens collected,,,,,,,,,,,,,,,,10/24/14,Specimens pending for testing,,,,,,,,,,,,,,,,10/24/14,Total specimens tested,,,,,,,,,,,,,,,,10/24/14,Newly reported deaths,40,,5,0,0,0,2,2,2,0,0,29,0,0,0,010/24/14,Total death/s in confirmed cases,,,,,,,,,,,,,,,,10/24/14,Total death/s in probable cases,,,,,,,,,,,,,,,,10/24/14,Total death/s in suspected cases,,,,,,,,,,,,,,,,10/24/14,"Total death/s in confirmed, 
- probable, suspected cases",2104,47,41,3,49,24,2,20,342,457,8,1060,26,7,8,1010/24/14,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,10/24/14,Newly reported contacts,241,0,0,0,6,0,0,20,0,10,0,205,0,0,0,010/24/14,Total contacts listed,,,,,,,,,,,,,,,,10/24/14,Currently under follow-up,7561,0,0,0,12,0,0,0,298,1780,0,4990,480,0,1,010/24/14,Contacts seen,7476,0,0,0,12,0,0,0,298,1780,0,4906,480,0,0,010/24/14,"Contacts who completed 21 day 
- follow-up",232,0,0,0,0,0,0,0,21,0,0,205,6,0,0,010/24/14,Contacts lost to follow-up,16,0,0,0,0,0,0,0,0,15,0,0,0,0,0,110/24/14,New admissions,,,,,,,,,,,,,,,,10/24/14,"Total no. currently in Treatment 
- Units",324,,,,,,,,,,,,,,,10/24/14,Total discharges,,,,,,,,,,,,,,,,10/24/14,Cumulative admission/isolation,,,,,,,,,,,,,,,,10/24/14,Newly Reported Cases in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,010/24/14,Cumulative cases among HCW,299,11,23,0,5,4,0,0,22,66,1,153,11,2,0,110/24/14,Newly Reported deaths in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,010/24/14,Cumulative deaths among HCW,123,6,8,0,2,1,0,0,16,30,0,58,2,0,0,010/24/14,New Case/s (Suspected),23,,3,0,0,0,0,0,0,1,0,19,0,0,0,010/24/14,New Case/s (Probable),12,,0,0,0,0,0,0,0,1,0,11,0,0,0,010/24/14,New case/s (confirmed),0,,0,0,0,0,0,0,0,0,0,0,0,0,0,010/24/14,Total suspected cases,2429,75,161,6,36,28,2,12,168,347,10,1480,82,7,5,1010/24/14,Total probable cases,1592,,38,35,2,69,9,0,13,151,493,2,672,100,4,110/24/14,Total confirmed cases,2232,60,69,4,16,22,2,2,304,279,2,1349,98,7,4,1410/24/14,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,10/24/14,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,10/24/14,"Cumulative confirmed, probable and suspected cases",6253,173,265,12,121,59,4,27,623,1119,14,3501,280,18,10,27
+Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand Cape Mount,Grand Gedeh,Grand Kru,Lofa County,Margibi County,Maryland County,Montserrado County,Nimba County,River Gee County,RiverCess County,Sinoe County
+10/24/14,Specimens collected,,,,,,,,,,,,,,,,
+10/24/14,Specimens pending for testing,,,,,,,,,,,,,,,,
+10/24/14,Total specimens tested,,,,,,,,,,,,,,,,
+10/24/14,Newly reported deaths,40,,5,0,0,0,2,2,2,0,0,29,0,0,0,0
+10/24/14,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
+10/24/14,Total death/s in probable cases,,,,,,,,,,,,,,,,
+10/24/14,Total death/s in suspected cases,,,,,,,,,,,,,,,,
+10/24/14,"Total death/s in confirmed, probable, suspected cases",2104,47,41,3,49,24,2,20,342,457,8,1060,26,7,8,10
+10/24/14,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/24/14,Newly reported contacts,241,0,0,0,6,0,0,20,0,10,0,205,0,0,0,0
+10/24/14,Total contacts listed,,,,,,,,,,,,,,,,
+10/24/14,Currently under follow-up,7561,0,0,0,12,0,0,0,298,1780,0,4990,480,0,1,0
+10/24/14,Contacts seen,7476,0,0,0,12,0,0,0,298,1780,0,4906,480,0,0,0
+10/24/14,"Contacts who completed 21 day follow-up",232,0,0,0,0,0,0,0,21,0,0,205,6,0,0,0
+10/24/14,Contacts lost to follow-up,16,0,0,0,0,0,0,0,0,15,0,0,0,0,0,1
+10/24/14,New admissions,,,,,,,,,,,,,,,,
+10/24/14,"Total no. currently in Treatment Units",324,,,,,,,,,,,,,,,
+10/24/14,Total discharges,,,,,,,,,,,,,,,,
+10/24/14,Cumulative admission/isolation,,,,,,,,,,,,,,,,
+10/24/14,Newly Reported Cases in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+10/24/14,Cumulative cases among HCW,299,11,23,0,5,4,0,0,22,66,1,153,11,2,0,1
+10/24/14,Newly Reported deaths in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+10/24/14,Cumulative deaths among HCW,123,6,8,0,2,1,0,0,16,30,0,58,2,0,0,0
+10/24/14,New Case/s (Suspected),23,,3,0,0,0,0,0,0,1,0,19,0,0,0,0
+10/24/14,New Case/s (Probable),12,,0,0,0,0,0,0,0,1,0,11,0,0,0,0
+10/24/14,New case/s (confirmed),0,,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+10/24/14,Total suspected cases,2429,75,161,6,36,28,2,12,168,347,10,1480,82,7,5,10
+10/24/14,Total probable cases,1592,,38,35,2,69,9,0,13,151,493,2,672,100,4,1
+10/24/14,Total confirmed cases,2232,60,69,4,16,22,2,2,304,279,2,1349,98,7,4,14
+10/24/14,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/24/14,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
+10/24/14,"Cumulative confirmed, probable and suspected cases",6253,173,265,12,121,59,4,27,623,1119,14,3501,280,18,10,27

--- a/liberia_data/2014-10-25-v163.csv
+++ b/liberia_data/2014-10-25-v163.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/25/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/25/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/25/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/25/2014,"Total death/s in confirmed, 
- probable, suspected cases",2106,47,41,3,49,24,2,20,342,457,10,1060,26,7,8,10
-10/25/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/25/2014,"Total death/s in confirmed, probable, suspected cases",2106,47,41,3,49,24,2,20,342,457,10,1060,26,7,8,10
+10/25/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/25/2014,Newly reported contacts,361,,,,,30,0,0,9,38,0,284,0,0,0,0
 10/25/2014,Total contacts listed,,,,,,,,,,,,,,,,
 10/25/2014,Currently under follow-up,7267,,,,,263,0,0,286,1790,0,4838,0,0,0,90
 10/25/2014,Contacts seen,7254,,,,,261,0,0,286,1790,0,4827,0,0,0,90
-10/25/2014,"Contacts who completed 21 day 
- follow-up",214,,,,,0,4,0,27,20,0,163,0,0,0,0
+10/25/2014,"Contacts who completed 21 day follow-up",214,,,,,0,4,0,27,20,0,163,0,0,0,0
 10/25/2014,Contacts lost to follow-up,21,,,,,21,0,0,0,0,0,0,0,0,0,0
 10/25/2014,New admissions,,,,,,,,,,,,,,,,
-10/25/2014,"Total no. currently in Treatment 
- Units",283,,,,,,,,2,,,281,,,,
+10/25/2014,"Total no. currently in Treatment Units",283,,,,,,,,2,,,281,,,,
 10/25/2014,Total discharges,,,,,,,,,,,,,,,,
 10/25/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/25/2014,Newly Reported Cases in HCW,0,,,,,0,0,,0,,0,0,,,,
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/25/2014,Total suspected cases,2431,75,161,6,34,28,2,12,168,349,12,1480,82,7,5,10
 10/25/2014,Total probable cases,1596,38,35,2,69,9,0,13,151,497,2,672,100,4,1,3
 10/25/2014,Total confirmed cases,2240,60,69,4,17,22,2,2,304,286,2,1349,98,7,4,14
-10/25/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-10/25/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+10/25/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/25/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 10/25/2014,"Cumulative confirmed, probable and suspected cases",6267,173,265,12,120,59,4,27,623,1132,16,3501,280,18,10,27

--- a/liberia_data/2014-10-27-v165.csv
+++ b/liberia_data/2014-10-27-v165.csv
@@ -1,7 +1,33 @@
-Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand Cape Mount,Grand Gedeh,Grand Kru,Lofa County,Margibi County,Maryland County,Montserrado County,Nimba County,River Gee County,RiverCess County,Sinoe County10/27/14,Specimens collected,,,,,,,,,,,,,,,,10/27/14,Specimens pending for testing,,,,,,,,,,,,,,,,10/27/14,Total specimens tested,,,,,,,,,,,,,,,,10/27/14,Newly reported deaths,26,,0,,0,0,0,2,3,2,0,17,0,0,2,010/27/14,Total death/s in confirmed cases,,,,,,,,,,,,,,,,10/27/14,Total death/s in probable cases,,,,,,,,,,,,,,,,10/27/14,Total death/s in suspected cases,,,,,,,,,,,,,,,,10/27/14,"Total death/s in confirmed, 
- probable, suspected cases",2446,78,68,3,49,28,3,20,344,488,11,1296,31,8,9,1010/27/14,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,10/27/14,Newly reported contacts,279,0,0,0,20,12,15,0,210,0,0,22,0,,,10/27/14,Total contacts listed,,,,,,,,,,,,,,,,10/27/14,Currently under follow-up,8001,70,12,218,0,0,788,1784,11,4532,480,0,23,83,,10/27/14,Contacts seen,7910,70,12,218,0,0,788,1784,11,4441,480,0,23,83,,10/27/14,"Contacts who completed 21 day 
- follow-up",770,0,0,23,24,0,15,21,0,536,0,31,113,7,,10/27/14,Contacts lost to follow-up,22,0,0,21,0,0,0,0,0,1,0,0,0,0,,10/27/14,New admissions,,,,,,,,,,,,,,,,10/27/14,"Total no. currently in Treatment 
- Units",320,,24,,,,,,3,,,283,10,,,10/27/14,Total discharges,,,,,,,,,,,,,,,,10/27/14,Cumulative admission/isolation,,,,,,,,,,,,,,,,10/27/14,Newly Reported Cases in HCW,0,,0,,0,0,0,0,0,0,0,0,0,0,0,010/27/14,Cumulative cases among HCW,304,11,23,0,5,4,0,0,22,67,1,157,11,2,0,110/27/14,Newly Reported deaths in HCW,0,,0,,0,0,0,0,0,0,0,0,0,0,0,010/27/14,Cumulative deaths among HCW,146,8,11,0,2,1,0,0,16,35,0,71,2,0,0,010/27/14,New Case/s (Suspected),14,,0,,0,0,0,0,0,3,0,10,0,0,1,010/27/14,New Case/s (Probable),13,,0,,1,0,0,0,0,3,0,8,0,0,1,010/27/14,New case/s (confirmed),,,,,,,,,,,,,,,,10/27/14,Total suspected cases,2430,60,160,6,37,26,2,12,168,354,12,1489,82,7,5,1010/27/14,Total probable cases,1595,43,35,2,68,10,0,13,150,490,2,675,99,4,1,310/27/14,Total confirmed cases,2303,70,73,4,16,23,2,2,304,288,2,1395,99,7,4,1410/27/14,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,10/27/14,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,10/27/14,"Cumulative confirmed, probable and suspected cases",6329,173,268,12,121,59,4,27,622,1132,16,3559,280,18,11,27
+Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand Cape Mount,Grand Gedeh,Grand Kru,Lofa County,Margibi County,Maryland County,Montserrado County,Nimba County,River Gee County,RiverCess County,Sinoe County
+10/27/14,Specimens collected,,,,,,,,,,,,,,,,
+10/27/14,Specimens pending for testing,,,,,,,,,,,,,,,,
+10/27/14,Total specimens tested,,,,,,,,,,,,,,,,
+10/27/14,Newly reported deaths,26,,0,,0,0,0,2,3,2,0,17,0,0,2,0
+10/27/14,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
+10/27/14,Total death/s in probable cases,,,,,,,,,,,,,,,,
+10/27/14,Total death/s in suspected cases,,,,,,,,,,,,,,,,
+10/27/14,"Total death/s in confirmed, probable, suspected cases",2446,78,68,3,49,28,3,20,344,488,11,1296,31,8,9,10
+10/27/14,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/27/14,Newly reported contacts,279,0,0,0,20,12,15,0,210,0,0,22,0,,,
+10/27/14,Total contacts listed,,,,,,,,,,,,,,,,
+10/27/14,Currently under follow-up,8001,70,12,218,0,0,788,1784,11,4532,480,0,23,83,,
+10/27/14,Contacts seen,7910,70,12,218,0,0,788,1784,11,4441,480,0,23,83,,
+10/27/14,"Contacts who completed 21 day follow-up",770,0,0,23,24,0,15,21,0,536,0,31,113,7,,
+10/27/14,Contacts lost to follow-up,22,0,0,21,0,0,0,0,0,1,0,0,0,0,,
+10/27/14,New admissions,,,,,,,,,,,,,,,,
+10/27/14,"Total no. currently in Treatment Units",320,,24,,,,,,3,,,283,10,,,
+10/27/14,Total discharges,,,,,,,,,,,,,,,,
+10/27/14,Cumulative admission/isolation,,,,,,,,,,,,,,,,
+10/27/14,Newly Reported Cases in HCW,0,,0,,0,0,0,0,0,0,0,0,0,0,0,0
+10/27/14,Cumulative cases among HCW,304,11,23,0,5,4,0,0,22,67,1,157,11,2,0,1
+10/27/14,Newly Reported deaths in HCW,0,,0,,0,0,0,0,0,0,0,0,0,0,0,0
+10/27/14,Cumulative deaths among HCW,146,8,11,0,2,1,0,0,16,35,0,71,2,0,0,0
+10/27/14,New Case/s (Suspected),14,,0,,0,0,0,0,0,3,0,10,0,0,1,0
+10/27/14,New Case/s (Probable),13,,0,,1,0,0,0,0,3,0,8,0,0,1,0
+10/27/14,New case/s (confirmed),,,,,,,,,,,,,,,,
+10/27/14,Total suspected cases,2430,60,160,6,37,26,2,12,168,354,12,1489,82,7,5,10
+10/27/14,Total probable cases,1595,43,35,2,68,10,0,13,150,490,2,675,99,4,1,3
+10/27/14,Total confirmed cases,2303,70,73,4,16,23,2,2,304,288,2,1395,99,7,4,14
+10/27/14,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/27/14,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
+10/27/14,"Cumulative confirmed, probable and suspected cases",6329,173,268,12,121,59,4,27,622,1132,16,3559,280,18,11,27

--- a/liberia_data/2014-10-28-v166.csv
+++ b/liberia_data/2014-10-28-v166.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/28/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/28/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/28/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/28/2014,"Total death/s in confirmed, 
- probable, suspected cases",2471,79,3,50,28,3,22,344,489,11,1308,37,3,8,8,10
-10/28/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/28/2014,"Total death/s in confirmed, probable, suspected cases",2471,79,3,50,28,3,22,344,489,11,1308,37,3,8,8,10
+10/28/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/28/2014,Newly reported contacts,201,0,0,0,0,16,0,0,0,0,0,185,0,0,0,0
 10/28/2014,Total contacts listed,,,,,,,,,,,,,,,,
 10/28/2014,Currently under follow-up,5396,470,39,73,0,187,0,0,169,0,11,4341,0,0,23,83
 10/28/2014,Contacts seen,5354,468,39,47,0,187,0,0,169,0,11,4327,0,0,23,83
-10/28/2014,"Contacts who completed 21 day 
- follow-up",936,216,31,117,0,172,0,0,0,0,35,358,0,0,0,7
+10/28/2014,"Contacts who completed 21 day follow-up",936,216,31,117,0,172,0,0,0,0,35,358,0,0,0,7
 10/28/2014,Contacts lost to follow-up,22,0,0,0,0,22,0,0,0,0,0,0,0,0,0,0
 10/28/2014,New admissions,,,,,,,,,,,,,,,,
-10/28/2014,"Total no. currently in Treatment 
- Units",209,,22,,,,,,,,,187,,,,
+10/28/2014,"Total no. currently in Treatment Units",209,,22,,,,,,,,,187,,,,
 10/28/2014,Total discharges,,,,,,,,,,,,,,,,
 10/28/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/28/2014,Newly Reported Cases in HCW,0,,0,,0,0,0,0,0,0,0,0,0,0,0,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/28/2014,Total suspected cases,2452,60,160,6,38,26,2,14,168,355,12,1505,82,7,7,10
 10/28/2014,Total probable cases,1642,44,35,2,69,10,0,14,151,490,2,690,126,4,2,3
 10/28/2014,Total confirmed cases,2304,70,73,4,16,23,2,2,304,289,2,1395,99,7,4,14
-10/28/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-10/28/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+10/28/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/28/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 10/28/2014,"Cumulative confirmed, probable and suspected cases",6398,174,268,12,123,59,4,30,623,1134,16,3590,307,18,13,27

--- a/liberia_data/2014-10-29-v167.csv
+++ b/liberia_data/2014-10-29-v167.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/29/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/29/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/29/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/29/2014,"Total death/s in confirmed, 
- probable, suspected cases",2609,84,77,3,50,31,3,22,345,504,14,1408,39,8,11,10
-10/29/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/29/2014,"Total death/s in confirmed, probable, suspected cases",2609,84,77,3,50,31,3,22,345,504,14,1408,39,8,11,10
+10/29/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/29/2014,Newly reported contacts,299,1,30,0,0,0,3,1,0,0,0,242,0,0,22,0
 10/29/2014,Total contacts listed,,,,,,,,,,,,,,,,
 10/29/2014,Currently under follow-up,7220,468,69,0,0,187,0,0,169,1790,11,4180,224,0,39,83
 10/29/2014,Contacts seen,6823,468,69,0,0,0,0,0,0,1790,0,4150,224,0,39,83
-10/29/2014,"Contacts who completed 21 day 
- follow-up",571,223,0,0,0,0,0,0,43,0,0,91,214,0,0,0
+10/29/2014,"Contacts who completed 21 day follow-up",571,223,0,0,0,0,0,0,43,0,0,91,214,0,0,0
 10/29/2014,Contacts lost to follow-up,4,0,0,0,0,0,0,0,0,0,0,4,0,0,0,0
 10/29/2014,New admissions,,,,,,,,,,,,,,,,
-10/29/2014,"Total no. currently in Treatment 
- Units",204,,25,,,,,,3,,,166,10,,,
+10/29/2014,"Total no. currently in Treatment Units",204,,25,,,,,,3,,,166,10,,,
 10/29/2014,Total discharges,,,,,,,,,,,,,,,,
 10/29/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/29/2014,Newly Reported Cases in HCW,0,,0,,0,0,0,0,0,0,0,0,0,0,0,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/29/2014,Total suspected cases,2447,62,160,6,39,25,2,14,168,360,13,1493,81,7,7,10
 10/29/2014,Total probable cases,1612,43,35,2,70,9,0,14,151,478,2,674,125,4,2,3
 10/29/2014,Total confirmed cases,2395,72,73,4,16,25,2,2,304,299,3,1469,101,7,4,14
-10/29/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-10/29/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+10/29/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/29/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 10/29/2014,"Cumulative confirmed, probable and suspected cases",6454,177,268,12,125,59,4,30,623,1137,18,3636,307,18,13,27

--- a/liberia_data/2014-10-30-v168.csv
+++ b/liberia_data/2014-10-30-v168.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/30/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 10/30/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 10/30/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-10/30/2014,"Total death/s in confirmed, 
- probable, suspected cases",2636,84,76,3,50,43,3,22,345,508,14,1419,39,8,12,10
-10/30/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+10/30/2014,"Total death/s in confirmed, probable, suspected cases",2636,84,76,3,50,43,3,22,345,508,14,1419,39,8,12,10
+10/30/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 10/30/2014,Newly reported contacts,274,1,48,,0,1,,0,0,0,0,224,0,0,0,0
 10/30/2014,Total contacts listed,,,,,,,,,,,,,,,,
 10/30/2014,Currently under follow-up,7297,468,117,,11,188,,0,114,1783,0,4273,224,0,39,80
 10/30/2014,Contacts seen,7013,468,117,,11,188,,0,114,1783,0,4252,0,0,0,80
-10/30/2014,"Contacts who completed 21 day 
- follow-up",94,0,0,,1,0,,0,0,0,0,93,0,0,0,0
+10/30/2014,"Contacts who completed 21 day follow-up",94,0,0,,1,0,,0,0,0,0,93,0,0,0,0
 10/30/2014,Contacts lost to follow-up,0,0,0,,0,0,,0,0,0,0,0,0,0,0,0
 10/30/2014,New admissions,34,0,0,,,,,,0,,,34,0,,,
-10/30/2014,"Total no. currently in Treatment 
- Units",279,0,25,,,,,,0,,,244,10,,,
+10/30/2014,"Total no. currently in Treatment Units",279,0,25,,,,,,0,,,244,10,,,
 10/30/2014,Total discharges,53,0,0,,,,,,0,,,47,6,,,
 10/30/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 10/30/2014,Newly Reported Cases in HCW,1,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 10/30/2014,Total suspected cases,2438,61,150,6,39,28,2,14,168,364,13,1489,79,7,8,10
 10/30/2014,Total probable cases,1610,43,33,2,70,19,0,13,151,474,2,671,123,4,2,3
 10/30/2014,Total confirmed cases,2437,73,78,4,16,27,2,3,304,310,3,1486,106,7,4,14
-10/30/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-10/30/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+10/30/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+10/30/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 10/30/2014,"Cumulative confirmed, probable and suspected cases",6485,177,261,12,125,74,4,30,623,1148,18,3646,308,18,14,27

--- a/liberia_data/2014-11-02-v171.csv
+++ b/liberia_data/2014-11-02-v171.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 11/2/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 11/2/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 11/2/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-11/2/2014,"Total death/s in confirmed, 
- probable, suspected cases",2700,85,77,3,50,43,3,22,346,516,14,1465,44,8,14,10
-11/2/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+11/2/2014,"Total death/s in confirmed, probable, suspected cases",2700,85,77,3,50,43,3,22,346,516,14,1465,44,8,14,10
+11/2/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 11/2/2014,Newly reported contacts,12,0,0,0,0,0,0,0,0,0,0,12,0,0,0,0
 11/2/2014,Total contacts listed,,,,,,,,,,,,,,,,
 11/2/2014,Currently under follow-up,6919,0,102,0,11,188,0,0,114,1791,0,4419,173,0,41,80
 11/2/2014,Contacts seen,6464,0,102,0,0,0,0,0,0,1791,0,4398,173,0,0,0
-11/2/2014,"Contacts who completed 21 day 
- follow-up",169,0,15,0,0,0,0,0,0,0,0,154,0,0,0,0
+11/2/2014,"Contacts who completed 21 day follow-up",169,0,15,0,0,0,0,0,0,0,0,154,0,0,0,0
 11/2/2014,Contacts lost to follow-up,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 11/2/2014,New admissions,17,,2,,,,,,0,,,13,2,,,
-11/2/2014,"Total no. currently in Treatment 
- Units",235,,18,,,,,,0,,,211,6,,,
+11/2/2014,"Total no. currently in Treatment Units",235,,18,,,,,,0,,,211,6,,,
 11/2/2014,Total discharges,12,,9,,,,,,0,,,3,0,,,
 11/2/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 11/2/2014,Newly Reported Cases in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 11/2/2014,Total suspected cases,2445,61,150,6,39,28,2,14,168,367,13,1492,79,7,9,10
 11/2/2014,Total probable cases,1623,42,33,2,68,19,0,13,151,476,2,675,133,4,2,3
 11/2/2014,Total confirmed cases,2456,74,78,4,18,27,2,3,304,312,3,1499,106,7,5,14
-11/2/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-11/2/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+11/2/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+11/2/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 11/2/2014,"Cumulative confirmed, probable and suspected cases",6524,177,261,12,125,74,4,30,623,1155,18,3666,318,18,16,27

--- a/liberia_data/2014-11-04-c173.csv
+++ b/liberia_data/2014-11-04-c173.csv
@@ -6,20 +6,16 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 11/4/2014,Total death/s in confirmed cases,,,,,,,,,,,,,,,,
 11/4/2014,Total death/s in probable cases,,,,,,,,,,,,,,,,
 11/4/2014,Total death/s in suspected cases,,,,,,,,,,,,,,,,
-11/4/2014,"Total death/s in confirmed, 
- probable, suspected cases",1179,50,38,2,6,14,1,3,214,145,3,663,26,5,4,5
-11/4/2014,"Case Fatality Rate (CFR) - 
- Confirmed & Probable Cases",,,,,,,,,,,,,,,,
+11/4/2014,"Total death/s in confirmed, probable, suspected cases",1179,50,38,2,6,14,1,3,214,145,3,663,26,5,4,5
+11/4/2014,"Case Fatality Rate (CFR) - Confirmed & Probable Cases",,,,,,,,,,,,,,,,
 11/4/2014,Newly reported contacts,186,0,0,0,1,1,0,5,0,6,0,173,0,0,0,0
 11/4/2014,Total contacts listed,5695,39,102,48,40,211,0,5,89,1730,11,3199,173,0,0,48
 11/4/2014,Currently under follow-up,,,,,,,,,,,,,,,,
 11/4/2014,Contacts seen,5570,0,102,48,40,211,0,5,89,1730,0,3196,101,0,0,48
-11/4/2014,"Contacts who completed 21 day 
- follow-up",373,0,0,12,0,0,0,0,0,92,35,150,52,0,0,32
+11/4/2014,"Contacts who completed 21 day follow-up",373,0,0,12,0,0,0,0,0,92,35,150,52,0,0,32
 11/4/2014,Contacts lost to follow-up,4,2,0,0,0,0,0,0,0,0,0,2,0,0,0,0
 11/4/2014,New admissions,28,,1,,,,,,0,,,25,2,,,
-11/4/2014,"Total no. currently in Treatment 
- Units",230,,15,,,,,,1,,,205,6,,,
+11/4/2014,"Total no. currently in Treatment Units",230,,15,,,,,,1,,,205,6,,,
 11/4/2014,Total discharges,11,,3,,,,,,0,,,8,0,,,
 11/4/2014,Cumulative admission/isolation,,,,,,,,,,,,,,,,
 11/4/2014,Newly Reported Cases in HCW,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
@@ -32,8 +28,6 @@ Date,Variable,National,Bomi County,Bong County,Gbarpolu County,Grand Bassa,Grand
 11/4/2014,Total suspected cases,23,0,2,6,0,1,0,0,0,2,0,12,0,0,0,0
 11/4/2014,Total probable cases,3,0,0,0,0,0,0,0,0,2,0,18,0,0,0,0
 11/4/2014,Total confirmed cases,,,,,,,,,,,,,,,,
-11/4/2014,"Total Number of Confirmed Cases 
- of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
-11/4/2014,"Total Number of Confirmed Cases 
- of Guinean Nationality",,,,,,,,,,,,,,,,
+11/4/2014,"Total Number of Confirmed Cases of Sierra Leonean Nationality",,,,,,,,,,,,,,,,
+11/4/2014,"Total Number of Confirmed Cases of Guinean Nationality",,,,,,,,,,,,,,,,
 11/4/2014,"Cumulative confirmed, probable and suspected cases",6619,188,267,15,127,76,4,30,642,1159,18,3711,320,18,17,27


### PR DESCRIPTION
Some files used CRLF on some lines and LF on others. I fixed that by replacing all CRLF with LF from october 20th onwards.
